### PR TITLE
Let service start their own server, cloud pubsub provide router

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,6 +27,7 @@
         "--config",
         "${workspaceRoot}/packages/foundation/jest.integration.json",
         "--runInBand",
+        "--detectOpenHandles",
         "--coverage",
         "false",
         "${relativeFile}"

--- a/packages/chatengine/package.json
+++ b/packages/chatengine/package.json
@@ -19,7 +19,6 @@
     "@line/bot-sdk": "^6.7.1",
     "adm-zip": "^0.4.13",
     "dialogflow": "^0.9.1",
-    "express": "^4.17.1",
     "fs-extra": "^8.0.1",
     "node-fetch": "^2.6.0",
     "nodemon": "^1.19.1",
@@ -37,5 +36,8 @@
     "ts-node": "^8.1.0",
     "tslint": "^5.16.0",
     "typescript": "^3.4.5"
+  },
+  "peerDependencies": {
+    "express": "^4.17.1"
   }
 }

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -11,7 +11,6 @@
     "prepublish": "yarn build"
   },
   "devDependencies": {
-    "@types/body-parser": "^1.17.0",
     "@types/express": "^4.16.1",
     "@types/jest": "^24.0.13",
     "@types/node-fetch": "^2.3.4",
@@ -23,8 +22,10 @@
     "@google-cloud/logging-winston": "^0.11.1",
     "@google-cloud/pubsub": "^0.28.1",
     "@google-cloud/storage": "^2.5.0",
-    "body-parser": "^1.19.0",
-    "express": "^4.17.1",
-    "ulid": "^2.3.0"
+    "ulid": "^2.3.0",
+    "winston": "^3.2.1"
+  },
+  "peerDependencies": {
+    "express": "^4.17.1"
   }
 }

--- a/packages/fulfillment/__test__/follow.integration.ts
+++ b/packages/fulfillment/__test__/follow.integration.ts
@@ -1,12 +1,11 @@
 import { randomFollowMessageIntent, randomIncomingMessage } from '@shio-bot/foundation/entities/__test__/random'
-import { createPubsubIntegrationClient, expectFulfillment } from './pubsub';
-import { UnPromise } from '../app/entities';
+import { createPubsubIntegrationClient, expectFulfillment } from './pubsub'
+import { UnPromise } from '../app/entities'
 
 describe('Follow intent test', () => {
+  let outgoingPubsub: UnPromise<ReturnType<typeof createPubsubIntegrationClient>>
 
-  let outgoingPubsub: UnPromise< ReturnType<typeof createPubsubIntegrationClient>>
-
-  jest.setTimeout(60*1000)
+  jest.setTimeout(60 * 1000)
 
   beforeAll(async () => {
     outgoingPubsub = await createPubsubIntegrationClient()
@@ -18,7 +17,7 @@ describe('Follow intent test', () => {
     let message = await outgoingPubsub.sendIncomingMessage(incomingMessage)
 
     expect(message.source.userId).toEqual(incomingMessage.source.userId)
-    expectFulfillment('follow', (fulfillment) => {
+    expectFulfillment('follow', fulfillment => {
       expect(fulfillment.parameters.isCompleted).toBeTruthy()
       expect(fulfillment.parameters.userId).toBeDefined()
       expect(fulfillment.parameters.chatSessionId).toBeDefined()
@@ -26,17 +25,14 @@ describe('Follow intent test', () => {
 
     message = await outgoingPubsub.sendIncomingMessage(incomingMessage)
     expect(message.source.userId).toEqual(incomingMessage.source.userId)
-    expectFulfillment('follow', (fulfillment) => {
+    expectFulfillment('follow', fulfillment => {
       expect(fulfillment.parameters.isCompleted).toBeFalsy()
       expect(fulfillment.parameters.userId).toBeUndefined()
       expect(fulfillment.parameters.chatSessionId).toBeUndefined()
     })(message)
-
   })
-
 
   afterAll(async () => {
     await outgoingPubsub.clean()
   })
 })
-

--- a/packages/fulfillment/app/repositories/__test__/user.integration.ts
+++ b/packages/fulfillment/app/repositories/__test__/user.integration.ts
@@ -1,6 +1,7 @@
 import { DatastoreUserRepository } from '../user'
 import { WithSystemOperation, WithWhere, WithOperationOwner } from '../common'
 import { createDatastoreInstance, WithDatastoreAPIEndpoint } from '@shio-bot/foundation'
+import { User } from '../../entities'
 
 describe('DatastoreUserRepository test', () => {
   let userRepo: DatastoreUserRepository
@@ -19,7 +20,7 @@ describe('DatastoreUserRepository test', () => {
     const user = await userRepo.findById(k.id, WithOperationOwner(k.id))
     expect(user!.displayName).toEqual('TEST_USER')
     await userRepo.remove(
-      WithWhere({
+      WithWhere<User>({
         displayName: {
           Equal: 'TEST_USER'
         }

--- a/packages/fulfillment/cmd/playground.ts
+++ b/packages/fulfillment/cmd/playground.ts
@@ -9,6 +9,7 @@ import {
   WithDatastoreProjectId
 } from '@shio-bot/foundation'
 import * as uuid from 'uuid/v4'
+import * as express from 'express'
 
 // if you want to use local development datastore server
 // insert datastore endpoint to CrateDatastoreInstance
@@ -44,19 +45,28 @@ async function Run() {
   await cloudpubsub.prepareTopic()
   const [subs] = await cloudpubsub.incomingTopic.getSubscriptions()
 
-  await Promise.all(subs.map(async sub => {
-    console.log(sub.name)
-    const meta = await sub.getMetadata()
-    console.log(meta)
-  }))
-  cloudpubsub.app.listen(8080)
+  await Promise.all(
+    subs.map(async sub => {
+      console.log(sub.name)
+      const meta = await sub.getMetadata()
+      console.log(meta)
+    })
+  )
+
+  const app = express()
+  app.use(express.json())
+  app.use('/', cloudpubsub.messageRouter)
+  app.get('/', (req, res) => res.status(200).send('ok'))
+  let server = app.listen(8080, () => {
+    console.log('test server started ', 8080)
+  })
 
   cloudpubsub.SubscribeIncommingMessage(async (message, ack) => {
     console.log(message)
     ack()
   })
 
-  cloudpubsub.SubscribeOutgoingMessage(async (message, ack)=> {
+  cloudpubsub.SubscribeOutgoingMessage(async (message, ack) => {
     console.log(message)
     ack()
   })

--- a/packages/fulfillment/package.json
+++ b/packages/fulfillment/package.json
@@ -23,7 +23,7 @@
     "inspect": true
   },
   "scripts": {
-    "start":"node cmd/entry.js",
+    "start": "node cmd/entry.js",
     "dev": "sh ../../scripts/clean.bash && nodemon",
     "build": "yarn tsc",
     "integration": "yarn jest --config jest.integration.json",
@@ -36,17 +36,15 @@
   },
   "dependencies": {
     "@google-cloud/datastore": "^3.1.2",
-    "@google-cloud/logging-winston": "^0.11.1",
     "@google-cloud/pubsub": "^0.28.1",
     "@shio-bot/foundation": "^1.0.6",
     "dataloader": "^1.4.0",
+    "express": "^4.17.1",
     "joi": "^14.3.1",
     "node-fetch": "^2.6.0",
-    "ulid": "^2.3.0",
-    "winston": "^3.2.1"
+    "ulid": "^2.3.0"
   },
   "devDependencies": {
-    "typescript": "^3.4.5",
     "@types/jest": "^24.0.12",
     "@types/joi": "^14.3.3",
     "@types/node-fetch": "^2.3.4",
@@ -57,6 +55,7 @@
     "ora": "^3.4.0",
     "ts-jest": "^24.0.2",
     "ts-node": "^8.1.0",
+    "typescript": "^3.4.5",
     "uuid": "^3.3.2"
   }
 }

--- a/packages/web/app/bootstrap.ts
+++ b/packages/web/app/bootstrap.ts
@@ -1,96 +1,45 @@
 import { server } from './server'
-import { Configurations, PubSubSettings } from './types'
+import { Configurations, PubSubSettings, Endpoint } from './types'
 import { chatEndpoint } from './endpoints/chat'
-import {
-  createCloudPubSubInstance,
-  WithClientConfig,
-  CloudPubsubMessageChannelTransport,
-  MessageChannelTransport,
-  PublishIncommingMessageInput,
-  SubscribeIncomingMessageListener,
-  PublishOutgoingMessageInput,
-  SubscribeOutgoingMessageListener
-} from '@shio-bot/foundation'
+import { createCloudPubSubInstance, WithClientConfig, CloudPubsubMessageChannelTransport, SubscribeOutgoingMessageListener } from '@shio-bot/foundation'
 import { ChatEngine } from '@shio-bot/chatengine'
 import { fulfillment } from './fulfillment'
 import { intentMessageHandler, fulfillmentMessageHandler } from './handlers'
+import { Router } from 'express'
+import { EchoPubSubTransport, MessageChannelTransportExt } from './internal'
 
-class EchoPubSubTransport implements MessageChannelTransport {
-  private incomingMessageListener: SubscribeIncomingMessageListener[] = []
-  private outcomingMessageListener: SubscribeOutgoingMessageListener[] = []
+const msgPubsubPath = '/msgpubsub'
 
-  constructor() {
-    this.SubscribeIncommingMessage(
-      ((input: PublishIncommingMessageInput, ack: () => void) => {
-        this.onIncomingMessage(input, ack)
-      }).bind(this)
-    )
-  }
-
-  private onIncomingMessage(input: PublishIncommingMessageInput, ack: () => void) {
-    let fulfillment: any = {
-      name: input.intent.name,
-      parameters: {
-        isCompleted: true
-      }
-    }
-
-    this.PublishOutgoingMessage({
-      fulfillment: [fulfillment],
-      provider: input.provider,
-      replyToken: input.replyToken,
-      languageCode: input.languageCode,
-      source: input.source,
-      requestId: input.requestId
-    })
-    ack()
-  }
-
-  async PublishIncommingMessage(input: PublishIncommingMessageInput): Promise<void> {
-    this.incomingMessageListener.forEach(listener => listener.bind(this)(input, () => {}))
-  }
-  SubscribeIncommingMessage(listener: SubscribeIncomingMessageListener): void {
-    this.incomingMessageListener.push(listener)
-  }
-  UnsubscribeAllIncomingMessage(): void {
-    this.incomingMessageListener = []
-  }
-  async PublishOutgoingMessage(input: PublishOutgoingMessageInput): Promise<void> {
-    this.outcomingMessageListener.forEach(listener => listener(input, () => {}))
-  }
-  SubscribeOutgoingMessage(listener: SubscribeOutgoingMessageListener): void {
-    this.outcomingMessageListener.push(listener)
-  }
-  UnsubscribeAllOutgoingMessage(): void {
-    this.outcomingMessageListener = []
-  }
-}
-
-const createPubsubTransportInstance = async (settings: PubSubSettings, serviceName: string): Promise<MessageChannelTransport> => {
+const createPubsubTransportInstance = async (settings: PubSubSettings, serviceName: string): Promise<MessageChannelTransportExt> => {
   if (settings.devPubSub) {
     return new EchoPubSubTransport()
   }
 
   let pubsub = await createCloudPubSubInstance(WithClientConfig(settings.cloudPubSub || {}))
-
   return new CloudPubsubMessageChannelTransport({ pubsub, serviceName })
+}
+
+function makePubsubEndpoint(pubsub: MessageChannelTransportExt): Endpoint {
+  let ep: Endpoint = pubsub.messageRouter as any
+  ep.path = msgPubsubPath
+  return ep
 }
 
 export async function bootstrap(config: Configurations) {
   let chatEngine = new ChatEngine(config.chatEngine)
-  let cloudPubSub = await createPubsubTransportInstance(config.pubsub, config.serviceName)
-  let ff = fulfillment(cloudPubSub)
-
+  let pubsub = await createPubsubTransportInstance(config.pubsub, config.serviceName)
+  let ff = fulfillment(pubsub)
   let intentDetector = chatEngine.intentDetectorProvider.get(config.intentProvider)
 
   let inMsgHandler = intentMessageHandler(ff, intentDetector, chatEngine.messagingClientProvider)
   let outMsgHandler = fulfillmentMessageHandler(chatEngine.messagingClientProvider)
 
+  pubsub.createOutgoingSubscriptionConfig(`${config.host}${msgPubsubPath}`)
   ff.onFulfillment(outMsgHandler)
+
   chatEngine.onMessageReceived(inMsgHandler.handle)
 
-  let eps = [chatEndpoint(chatEngine)]
-
+  let eps: Endpoint[] = [chatEndpoint(chatEngine), makePubsubEndpoint(pubsub)]
   return server(config, ...eps)
     .start()
     .then(_ => console.log('D O N E'))

--- a/packages/web/app/internal.ts
+++ b/packages/web/app/internal.ts
@@ -1,0 +1,80 @@
+import {
+  MessageChannelTransport,
+  MessageChannelManager,
+  SubscribeIncomingMessageListener,
+  SubscribeOutgoingMessageListener,
+  PublishIncommingMessageInput,
+  PublishOutgoingMessageInput
+} from '@shio-bot/foundation'
+
+import { Router } from 'express'
+
+export interface MessageChannelTransportExt extends MessageChannelTransport, MessageChannelManager {}
+
+export class EchoPubSubTransport implements MessageChannelTransportExt {
+  private incomingMessageListener: SubscribeIncomingMessageListener[] = []
+  private outcomingMessageListener: SubscribeOutgoingMessageListener[] = []
+
+  constructor() {
+    this.SubscribeIncommingMessage(
+      ((input: PublishIncommingMessageInput, ack: () => void) => {
+        this.onIncomingMessage(input, ack)
+      }).bind(this)
+    )
+  }
+
+  private onIncomingMessage(input: PublishIncommingMessageInput, ack: () => void) {
+    let fulfillment: any = {
+      name: input.intent.name,
+      parameters: {
+        isCompleted: true
+      }
+    }
+
+    this.PublishOutgoingMessage({
+      fulfillment: [fulfillment],
+      provider: input.provider,
+      replyToken: input.replyToken,
+      languageCode: input.languageCode,
+      source: input.source,
+      requestId: input.requestId
+    })
+    ack()
+  }
+
+  async PublishIncommingMessage(input: PublishIncommingMessageInput): Promise<void> {
+    this.incomingMessageListener.forEach(listener => listener.bind(this)(input, () => {}))
+  }
+  SubscribeIncommingMessage(listener: SubscribeIncomingMessageListener): void {
+    this.incomingMessageListener.push(listener)
+  }
+  UnsubscribeAllIncomingMessage(): void {
+    this.incomingMessageListener = []
+  }
+  async PublishOutgoingMessage(input: PublishOutgoingMessageInput): Promise<void> {
+    this.outcomingMessageListener.forEach(listener => listener(input, () => {}))
+  }
+  SubscribeOutgoingMessage(listener: SubscribeOutgoingMessageListener): void {
+    this.outcomingMessageListener.push(listener)
+  }
+  UnsubscribeAllOutgoingMessage(): void {
+    this.outcomingMessageListener = []
+  }
+
+  get messageRouter(): Router {
+    return Router()
+  }
+
+  async createIncomingSubscriptionConfig(host: string): Promise<void> {
+    // do nothing
+  }
+  async createOutgoingSubscriptionConfig(host: string): Promise<void> {
+    // do nothing
+  }
+  async prepareTopic(): Promise<void> {
+    // do nothing
+  }
+  async purge(): Promise<void> {
+    // do nothing
+  }
+}

--- a/packages/web/app/server.ts
+++ b/packages/web/app/server.ts
@@ -1,11 +1,9 @@
 import * as express from 'express'
 import { Configurations, Endpoint } from './types'
-import * as bodyParser from 'body-parser'
 
 export const server = (config: Configurations, ...endpoints: Endpoint[]) => {
   let app = express()
-  app.use(bodyParser.urlencoded({ extended: true }))
-  app.use(bodyParser.json())
+  app.use(express.json())
 
   endpoints.forEach(e => app.use(e.path, e))
   const start = async (): Promise<void> =>

--- a/packages/web/app/types.ts
+++ b/packages/web/app/types.ts
@@ -5,6 +5,7 @@ import { ClientConfig } from '@google-cloud/pubsub/build/src/pubsub'
 
 export type Configurations = {
   serviceName: string
+  host: string
   port: number
   chatEngine: ChatEngineSettings
   pubsub: PubSubSettings

--- a/packages/web/cmd/dev.ts
+++ b/packages/web/cmd/dev.ts
@@ -4,6 +4,7 @@ import { Configurations } from '../app/types'
 function loadConfig(): Configurations {
   let config: Configurations = {
     serviceName: 'shio-api-dev',
+    host: 'http://localhost',
     port: 3000,
     chatEngine: {
       line: {

--- a/packages/web/cmd/entry.ts
+++ b/packages/web/cmd/entry.ts
@@ -10,11 +10,13 @@ async function run() {
   let projectId = GetEnvStringOrThrow('SHIO_API_PROJECT_ID')
   let bucket = GetEnvStringOrThrow('SHIO_API_BUCKET')
   let path = GetEnvStringOrThrow('SHIO_API_CONFIG_PATH')
+  let host = GetEnvStringOrThrow('SHIO_API_HOST')
   let port = GetEnvStringOrThrow('PORT')
 
   let storage = new GCPFileStorage(bucket, { projectId })
   let config = await loadConfig(storage, path)
   config.port = atoi(port)
+  config.host = host
 
   await bootstrap(config)
 }

--- a/packages/web/cmd/local.ts
+++ b/packages/web/cmd/local.ts
@@ -1,6 +1,22 @@
 import { bootstrap } from '../app/bootstrap'
 import { Configurations } from '../app/types'
 import { FileStorage, LocalFileStorage } from '@shio-bot/foundation'
+import { platform } from 'os'
+import { newLogger } from '@shio-bot/foundation'
+
+const log = newLogger()
+
+const getHostForIntegrationTest = () => {
+  let host = 'http://localhost'
+  if (platform() === 'darwin') {
+    log.info('Setup subscription for darwin platform')
+    host = 'http://host.docker.internal'
+  } else {
+    log.info('Setup subscription none darwin platform')
+    host = 'http://localhost'
+  }
+  return host
+}
 
 async function loadConfig(storage: FileStorage, path: string): Promise<Configurations> {
   return await storage.GetJSONObject<Configurations>(path)
@@ -9,6 +25,8 @@ async function loadConfig(storage: FileStorage, path: string): Promise<Configura
 async function run() {
   let storage = new LocalFileStorage(process.cwd())
   let config = await loadConfig(storage, 'credentials/config.local.json')
+  let host = getHostForIntegrationTest()
+  config.host = host
   await bootstrap(config)
 }
 

--- a/packages/web/env.example.yaml
+++ b/packages/web/env.example.yaml
@@ -1,5 +1,6 @@
 env_variables:
   SHIO_API_PROJECT_ID: catcat-local
+  SHIO_API_HOST: http://localhost
   SHIO_API_BUCKET: shio-bot-dev
   SHIO_API_CONFIG_PATH: credential/config.json
   PORT: 8080

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -33,14 +33,11 @@
   "dependencies": {
     "@shio-bot/chatengine": "^1.0.0",
     "@shio-bot/foundation": "^1.0.8",
-    "body-parser": "^1.19.0",
-    "express": "^4.17.1",
-    "winston": "^3.2.1"
+    "express": "^4.17.1"
   },
   "devDependencies": {
     "@types/express": "^4.16.1",
     "@types/jest": "^24.0.13",
-    "@types/winston": "^2.4.4",
     "jest": "^24.8.0",
     "typescript": "^3.5.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -676,7 +676,7 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/body-parser@*", "@types/body-parser@^1.16.8", "@types/body-parser@^1.17.0":
+"@types/body-parser@*", "@types/body-parser@^1.16.8":
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/@types/body-parser/-/body-parser-1.17.0.tgz#9f5c9d9bd04bb54be32d5eb9fc0d8c974e6cf58c"
   integrity sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==
@@ -1291,7 +1291,7 @@ binary-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
   integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
 
-body-parser@1.19.0, body-parser@^1.18.2, body-parser@^1.19.0:
+body-parser@1.19.0, body-parser@^1.18.2:
   version "1.19.0"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.19.0.tgz#96b2709e57c9c4e09a6fd66a8fd979844f69f08a"
   integrity sha512-dhEPs72UPbDnAQJ9ZKMNTP6ptJaionhP5cBb541nXPlW60Jepo9RV/a4fX4XWW9CuFNK22krhrj1+rgzifNCsw==
@@ -6710,6 +6710,11 @@ typescript@^3.4.5:
   version "3.4.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
   integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
+
+typescript@^3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.1.tgz#ba72a6a600b2158139c5dd8850f700e231464202"
+  integrity sha512-64HkdiRv1yYZsSe4xC1WVgamNigVYjlssIoaH2HcZF0+ijsk5YK2g0G34w9wJkze8+5ow4STd22AynfO6ZYYLw==
 
 uglify-js@^3.1.4:
   version "3.5.11"


### PR DESCRIPTION
- added property `messageRouter` in `MessageChannelManager`
- removed method `start` and `stop` in cloudpubsub
- fulfillment starts its own express server